### PR TITLE
Fix a problem with scalar observations

### DIFF
--- a/dm_control2gym/wrapper.py
+++ b/dm_control2gym/wrapper.py
@@ -54,6 +54,9 @@ def convertObservation(spec_obs):
         # no concatenation
         return list(spec_obs.values())[0]
     else:
+        for k, v in spec_obs.items():
+            if np.isscalar(v):
+                spec_obs[k] = np.array([v])
         # concatentation
         numdim = sum([np.int(np.prod(spec_obs[key].shape)) for key in spec_obs])
         space_obs = np.zeros((numdim,))


### PR DESCRIPTION
Hi! Thanks for an awesome repository!

I found a small bug. When observations are stored as scalar values, the wrapper doesn't work.

You can reproduce the bug by running 
```python
import dm_control2gym

env = dm_control2gym.make(domain_name="walker", task_name="run")

env.reset()
```

This pull request fixed the problem.